### PR TITLE
Fixed makeDataForView still ising cache when cacheView is set to false

### DIFF
--- a/src/Utils/WidgetRenderer.php
+++ b/src/Utils/WidgetRenderer.php
@@ -78,7 +78,7 @@ class WidgetRenderer
             return $this->renderTemplate($widget, ...$args);
         };
 
-        if (! $widget->cacheView) {
+        if ($widget->cacheView == false) {
             return $expensivePhpCode();
         }
 
@@ -105,11 +105,13 @@ class WidgetRenderer
             return $viewData;
         };
 
-        if ($widget->cacheView) {
+        if ($widget->cacheView == false) {
             $this->_viewData = $expensiveCode();
-        } else {
-            $this->_viewData = resolve(Cache::class)->cacheResult($args, $expensiveCode, $widget, 'dataProvider');
+            return;
         }
+
+        // We first try to get the output from the cache before trying to run the expensive $expensiveCode...
+        $this->_viewData = resolve(Cache::class)->cacheResult($args, $expensiveCode, $widget, 'dataProvider');
     }
 
     /**


### PR DESCRIPTION
This fixes an issue when widget does not render completely even though cacheView is set to false.

Issue shows up when trying to work with updated data like changed cookies or session variables.